### PR TITLE
操作对象可视化

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,8 @@ const checkDirExist = function (dir) {
   }
 }
 const copy = function (from, dist) {
+  console.log('当前根路径: ' + path.resolve('./'))
+  console.log('from dir: ' + from + '; ' + 'to dir: ' + dist)
   if (!checkDirExist(from)) {
     console.error('可复制的文件或者目录不存在')
     return false

--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ const checkDirExist = function (dir) {
   }
 }
 const copy = function (from, dist) {
-  console.info('vite-plugin-files-copy: from dir=' + from + '; ' + 'to dir=' + dist)
+  console.info('vite-plugin-files-copy: from_dir=' + from + '; ' + 'to_dir=' + dist)
   if (!checkDirExist(from)) {
     console.error('可复制的文件或者目录不存在')
     return false

--- a/main.js
+++ b/main.js
@@ -12,8 +12,7 @@ const checkDirExist = function (dir) {
   }
 }
 const copy = function (from, dist) {
-  console.log('当前根路径: ' + path.resolve('./'))
-  console.log('from dir: ' + from + '; ' + 'to dir: ' + dist)
+  console.info('vite-plugin-files-copy: from dir=' + from + '; ' + 'to dir=' + dist)
   if (!checkDirExist(from)) {
     console.error('可复制的文件或者目录不存在')
     return false
@@ -50,6 +49,7 @@ module.exports = function (options) {
     },
     async writeBundle() {
       const root = viteConfig.root
+      console.info('vite-plugin-files-copy: current_root_path=' + path.resolve('./'))
       try {
         options.patterns.forEach((item) => {
           if (item.from && item.to) {


### PR DESCRIPTION
开发文档要写清楚。如果 vite.config.js 文件里定义了 base 为 "./" ，那么打包工作的根目录将会是 src 文件夹 的所在目录。所以 一般是 from: "./src/static/css", to: "./dist/public/static/css" 这样才不会报错 "可复制的文件或者目录不存在"